### PR TITLE
Add BLE advertisement subscriptions and RSSI guard

### DIFF
--- a/drivers/LYWSD02MMC/device.js
+++ b/drivers/LYWSD02MMC/device.js
@@ -53,6 +53,8 @@ const FE95_OBJECTS = {
   temperatureHumidity: 0x100d,
 };
 const PASSIVE_FE95_DISCOVERY_MS = 4000;
+const ADVERTISEMENT_RATE_LIMIT_MS = 5000;
+const MIN_CONNECTABLE_RSSI = -85;
 
 class LYWSD02MMC_device extends Device {
   /**
@@ -105,6 +107,10 @@ class LYWSD02MMC_device extends Device {
       this.subscriptionInProgress = false;
       this.notificationTimeout = null;
       this.notificationCharacteristic = null;
+      this.advertisementSubscriptionActive = false;
+      this.lastCompleteAdvertisementAt = null;
+
+      await this.startAdvertisementSubscription();
 
       // Enable notifications and subscribe to them
       // not working / not required ?
@@ -678,6 +684,118 @@ class LYWSD02MMC_device extends Device {
     this.setNotificationTimeout();
   }
 
+  supportsAdvertisementSubscriptions() {
+    return Boolean(
+      typeof this.homey.hasFeature === "function"
+      && this.homey.hasFeature("ble-advertisements")
+      && this.homey.ble
+      && typeof this.homey.ble.subscribeToAdvertisements === "function"
+      && typeof this.homey.ble.unsubscribeFromAdvertisements === "function",
+    );
+  }
+
+  hasRecentCompleteAdvertisement() {
+    if (!this.lastCompleteAdvertisementAt) {
+      return false;
+    }
+
+    const maxAgeMs = Math.max(this.reconnectInterval * 1000, ADVERTISEMENT_RATE_LIMIT_MS * 2);
+    return Date.now() - this.lastCompleteAdvertisementAt <= maxAgeMs;
+  }
+
+  async startAdvertisementSubscription() {
+    if (!this.supportsAdvertisementSubscriptions()) {
+      this.log("BLE advertisement subscriptions are not available; using find/GATT fallback.");
+      return;
+    }
+
+    const peripheralUuid = this.getPeripheralUuid();
+    if (!peripheralUuid) {
+      this.log("Missing peripheral UUID; using find/GATT fallback.");
+      return;
+    }
+
+    try {
+      await this.homey.ble.subscribeToAdvertisements(
+        peripheralUuid,
+        { rateLimitMs: ADVERTISEMENT_RATE_LIMIT_MS },
+        (advertisement) => {
+          this.processAdvertisementUpdate(advertisement).catch((error) => {
+            this.logErrorDetails("Error processing subscribed BLE advertisement", error);
+          });
+        },
+      );
+      this.advertisementSubscriptionActive = true;
+      this.log(`Subscribed to BLE advertisements for ${peripheralUuid}`);
+    } catch (error) {
+      this.advertisementSubscriptionActive = false;
+      this.log(`Could not subscribe to BLE advertisements, using find/GATT fallback: ${error.message || error}`);
+    }
+  }
+
+  async stopAdvertisementSubscription() {
+    if (!this.advertisementSubscriptionActive || !this.supportsAdvertisementSubscriptions()) {
+      return;
+    }
+
+    const peripheralUuid = this.getPeripheralUuid();
+    if (!peripheralUuid) {
+      return;
+    }
+
+    try {
+      await this.homey.ble.unsubscribeFromAdvertisements(peripheralUuid);
+      this.log(`Unsubscribed from BLE advertisements for ${peripheralUuid}`);
+    } catch (error) {
+      this.log(`Failed to unsubscribe from BLE advertisements: ${error.message || error}`);
+    } finally {
+      this.advertisementSubscriptionActive = false;
+    }
+  }
+
+  async processAdvertisementUpdate(advertisement) {
+    if (!advertisement) {
+      return;
+    }
+
+    const store = typeof this.getStore === "function" ? this.getStore() : {};
+    const data = this.getData() || {};
+    const targetAddress = store && typeof store.address === "string" ? store.address : data.id;
+    const targetUuid = this.getPeripheralUuid();
+    if (!this.advertisementMatchesTarget(advertisement, targetAddress, targetUuid)) {
+      return;
+    }
+
+    this.logAdvertisementContext(advertisement);
+
+    if (typeof advertisement.rssi === "number") {
+      await this.safeSetCapabilityValue("measure_rssi", advertisement.rssi);
+    }
+
+    const parsedAdvertisement = this.parseFe95Advertisement(advertisement);
+    if (!parsedAdvertisement) {
+      return;
+    }
+
+    const passiveResult = await this.applyParsedAdvertisementValues(parsedAdvertisement);
+    if (passiveResult.hasCompleteMeasurement) {
+      this.lastCompleteAdvertisementAt = Date.now();
+      this.setWarning(null);
+      await this.stopBLESubscription();
+    }
+  }
+
+  async shouldSkipActiveConnection(advertisement) {
+    if (!advertisement || typeof advertisement.rssi !== "number" || advertisement.rssi > MIN_CONNECTABLE_RSSI) {
+      return false;
+    }
+
+    await this.processAdvertisementUpdate(advertisement);
+    this.log(`Skipping active BLE connection because RSSI is ${advertisement.rssi} dBm (threshold: ${MIN_CONNECTABLE_RSSI} dBm).`);
+    await this.setWarning(`RSSI too weak for active BLE connection (${advertisement.rssi} dBm); using advertisements only.`);
+    return true;
+  }
+
   /**
    * onAdded is called when the user adds the device, called just after pairing.
    */
@@ -743,11 +861,21 @@ class LYWSD02MMC_device extends Device {
   async onDeleted() {
     try {
       this.log("LYWSD02MMC BLE has been deleted");
+      await this.stopAdvertisementSubscription();
       await this.stopBLESubscription();
       this.polling = false;
       clearInterval(this.pollingInterval);
     } catch (error) {
       this.log(`Error during deletion: ${error}`);
+    }
+  }
+
+  async onUninit() {
+    await this.stopAdvertisementSubscription();
+    await this.stopBLESubscription();
+    if (this.pollingInterval) {
+      clearInterval(this.pollingInterval);
+      this.pollingInterval = null;
     }
   }
 
@@ -764,6 +892,10 @@ class LYWSD02MMC_device extends Device {
 
     try {
       const advertisement = await this.homey.ble.find(peripheralUuid);
+      if (await this.shouldSkipActiveConnection(advertisement)) {
+        return;
+      }
+
       peripheral = await advertisement.connect();
       this.log(`Connected to device: ${peripheralUuid}`);
 
@@ -823,6 +955,10 @@ class LYWSD02MMC_device extends Device {
       }
 
       const advertisement = await this.homey.ble.find(peripheralUuid);
+      if (await this.shouldSkipActiveConnection(advertisement)) {
+        return;
+      }
+
       peripheral = await advertisement.connect();
       this.log(`Connected to device: ${peripheralUuid}`);
       const deviceInfoService = await this.getServiceByUuid(peripheral, UUIDS.deviceInformationService);
@@ -862,6 +998,11 @@ class LYWSD02MMC_device extends Device {
     let peripheral;
 
     try {
+      if (this.advertisementSubscriptionActive && this.hasRecentCompleteAdvertisement()) {
+        this.log("Recent complete FE95 advertisement received; skipping GATT subscription for this poll.");
+        return;
+      }
+
       await this.stopBLESubscription();
       const advertisement = await this.homey.ble.find(peripheralUuid);
       this.logAdvertisementContext(advertisement);
@@ -875,6 +1016,10 @@ class LYWSD02MMC_device extends Device {
 
       // Set the RSSI capability value
       await this.safeSetCapabilityValue("measure_rssi", rssi);
+
+      if (await this.shouldSkipActiveConnection(advertisement)) {
+        return;
+      }
 
       const rssiPercentage = Math.round(Math.max(0, Math.min(100, ((rssi + 100) / 60) * 100)));
       this.log(`Device RSSI Percentage: ${rssiPercentage}%`);

--- a/drivers/xiaomi-thermometer-ble/device.js
+++ b/drivers/xiaomi-thermometer-ble/device.js
@@ -30,6 +30,85 @@ class MyDevice extends Device {
 
     // Get the initial temperature offset setting
     this.temperatureOffset = this.getSetting("temperature_offset") || 0;
+    this.advertisementSubscriptionActive = false;
+    await this.startAdvertisementSubscription();
+  }
+
+  getPeripheralUuid() {
+    const store = typeof this.getStore === "function" ? this.getStore() : {};
+    const storePeripheralUuid = store && typeof store.peripheralUuid === "string" ? store.peripheralUuid : "";
+    if (storePeripheralUuid) {
+      return storePeripheralUuid.toLowerCase().replace(/:/g, "");
+    }
+
+    const data = this.getData() || {};
+    const legacyId = typeof data.id === "string" ? data.id : "";
+    return legacyId.toLowerCase().replace(/:/g, "");
+  }
+
+  supportsAdvertisementSubscriptions() {
+    return Boolean(
+      typeof this.homey.hasFeature === "function"
+      && this.homey.hasFeature("ble-advertisements")
+      && this.homey.ble
+      && typeof this.homey.ble.subscribeToAdvertisements === "function"
+      && typeof this.homey.ble.unsubscribeFromAdvertisements === "function",
+    );
+  }
+
+  isUsingAdvertisementSubscription() {
+    return this.advertisementSubscriptionActive === true;
+  }
+
+  async startAdvertisementSubscription() {
+    if (!this.supportsAdvertisementSubscriptions()) {
+      this.log("BLE advertisement subscriptions are not available; using discovery polling fallback.");
+      return;
+    }
+
+    const peripheralUuid = this.getPeripheralUuid();
+    if (!peripheralUuid) {
+      this.log("Missing peripheral UUID; using discovery polling fallback.");
+      return;
+    }
+
+    try {
+      await this.homey.ble.subscribeToAdvertisements(
+        peripheralUuid,
+        { rateLimitMs: 5000 },
+        (advertisement) => {
+          this.updateTag(advertisement).catch((error) => this.error("Error processing advertisement:", error));
+        },
+      );
+      this.advertisementSubscriptionActive = true;
+      this.log(`Subscribed to BLE advertisements for ${peripheralUuid}`);
+      if (this.driver && typeof this.driver.managePolling === "function") {
+        this.driver.managePolling();
+      }
+    } catch (error) {
+      this.advertisementSubscriptionActive = false;
+      this.log(`Could not subscribe to BLE advertisements, using polling fallback: ${error.message || error}`);
+    }
+  }
+
+  async stopAdvertisementSubscription() {
+    if (!this.advertisementSubscriptionActive || !this.supportsAdvertisementSubscriptions()) {
+      return;
+    }
+
+    const peripheralUuid = this.getPeripheralUuid();
+    if (!peripheralUuid) {
+      return;
+    }
+
+    try {
+      await this.homey.ble.unsubscribeFromAdvertisements(peripheralUuid);
+      this.log(`Unsubscribed from BLE advertisements for ${peripheralUuid}`);
+    } catch (error) {
+      this.log(`Failed to unsubscribe from BLE advertisements: ${error.message || error}`);
+    } finally {
+      this.advertisementSubscriptionActive = false;
+    }
   }
 
   /**
@@ -70,13 +149,16 @@ class MyDevice extends Device {
    */
   async onDeleted() {
     this.log("Xiaomi ATC BLE has been deleted");
+    await this.stopAdvertisementSubscription();
+  }
+
+  async onUninit() {
+    await this.stopAdvertisementSubscription();
   }
 
   async updateTag(foundDevices) {
     try {
       this.log(`Updating measurements ${this.getName()}`);
-      let deviceData = this.getData();
-      let settings = this.getSettings();
       let mac = this.getData();
 
       // Add safeguard check if device is still available
@@ -85,7 +167,8 @@ class MyDevice extends Device {
         return;
       }
 
-      foundDevices.forEach((device) => {
+      const advertisements = Array.isArray(foundDevices) ? foundDevices : [foundDevices];
+      advertisements.forEach((device) => {
         if (device.address === mac["id"]) {
           this.log("Match!", mac, device.address);
           //this.log("Service Data:", device.serviceData);

--- a/drivers/xiaomi-thermometer-ble/driver.js
+++ b/drivers/xiaomi-thermometer-ble/driver.js
@@ -26,10 +26,14 @@ class MyDriver extends Driver {
   }
 
   managePolling() {
-    const devices = this.getDevices();
+    const devices = this.getDevices()
+      .filter((device) => !device.isUsingAdvertisementSubscription || !device.isUsingAdvertisementSubscription());
     if (devices.length > 0 && !this.polling) {
       this.polling = true;
-      this.addListener("poll", this.pollDevice.bind(this));
+      if (!this.pollListener) {
+        this.pollListener = this.pollDevice.bind(this);
+        this.addListener("poll", this.pollListener);
+      }
       this.emit("poll");
       this.log("Started polling BLE ATC devices.");
     } else if (devices.length === 0 && this.polling) {
@@ -68,6 +72,10 @@ class MyDriver extends Driver {
                 let new_device = {
                   name: device.localName,
                   data: { id: device.address },
+                  store: {
+                    peripheralUuid: device.uuid || device.address,
+                    address: device.address,
+                  },
                 };
                 devices.push(new_device);
                 this.log(`Device added for pairing: ${device.localName}, address: ${device.address}`);
@@ -93,7 +101,14 @@ class MyDriver extends Driver {
       let polling_interval = this.homey.settings.get("polling_interval") || 30;
       let scan_duration = this.homey.settings.get("scan_duration") || 20;
 
-      let devices = this.getDevices();
+      let devices = this.getDevices()
+        .filter((device) => !device.isUsingAdvertisementSubscription || !device.isUsingAdvertisementSubscription());
+
+      if (devices.length === 0) {
+        this.polling = false;
+        this.log("All ATC BLE devices use advertisement subscriptions. Polling is disabled.");
+        return;
+      }
 
       try {
         const foundDevices = await this.homey.ble.discover([], scan_duration * 1000);

--- a/drivers/xiaomi-thermometer-ble2/device.js
+++ b/drivers/xiaomi-thermometer-ble2/device.js
@@ -1,6 +1,8 @@
 "use strict";
 
 const { Device } = require("homey");
+const ADVERTISEMENT_RATE_LIMIT_MS = 5000;
+const MIN_CONNECTABLE_RSSI = -85;
 
 class MyDevice extends Device {
   /**
@@ -61,7 +63,9 @@ class MyDevice extends Device {
 
     // Get the reconnect interval setting, default to 5 minutes
     this.reconnectInterval = this.getSetting("reconnect_interval") || 5 * 60;
+    this.advertisementSubscriptionActive = false;
 
+    await this.startAdvertisementSubscription();
     // Enable notifications and subscribe to them
     await this.enableNotifications();
     await this.subscribeToBLENotifications();
@@ -69,6 +73,132 @@ class MyDevice extends Device {
     // Set up polling
     this.addListener("poll", this.subscribeToBLENotifications.bind(this));
     this.pollDevice();
+  }
+
+  getPeripheralUuid() {
+    const store = typeof this.getStore === "function" ? this.getStore() : {};
+    const storePeripheralUuid = store && typeof store.peripheralUuid === "string" ? store.peripheralUuid : "";
+    if (storePeripheralUuid) {
+      return storePeripheralUuid.toLowerCase().replace(/:/g, "");
+    }
+
+    const data = this.getData() || {};
+    const legacyId = typeof data.id === "string" ? data.id : "";
+    return legacyId.toLowerCase().replace(/:/g, "");
+  }
+
+  advertisementMatchesTarget(advertisement) {
+    const store = typeof this.getStore === "function" ? this.getStore() : {};
+    const data = this.getData() || {};
+    const targetAddress = (store.address || data.id || "").toLowerCase();
+    const targetUuid = this.getPeripheralUuid();
+    const advertisementAddress = (advertisement && advertisement.address || "").toLowerCase();
+    const advertisementUuid = (advertisement && advertisement.uuid || "").toLowerCase().replace(/:/g, "");
+
+    return Boolean(
+      (targetAddress && advertisementAddress === targetAddress)
+      || (targetUuid && advertisementUuid === targetUuid),
+    );
+  }
+
+  supportsAdvertisementSubscriptions() {
+    return Boolean(
+      typeof this.homey.hasFeature === "function"
+      && this.homey.hasFeature("ble-advertisements")
+      && this.homey.ble
+      && typeof this.homey.ble.subscribeToAdvertisements === "function"
+      && typeof this.homey.ble.unsubscribeFromAdvertisements === "function",
+    );
+  }
+
+  async startAdvertisementSubscription() {
+    if (!this.supportsAdvertisementSubscriptions()) {
+      this.log("BLE advertisement subscriptions are not available; using find/GATT fallback.");
+      return;
+    }
+
+    const peripheralUuid = this.getPeripheralUuid();
+    if (!peripheralUuid) {
+      this.log("Missing peripheral UUID; using find/GATT fallback.");
+      return;
+    }
+
+    try {
+      await this.homey.ble.subscribeToAdvertisements(
+        peripheralUuid,
+        { rateLimitMs: ADVERTISEMENT_RATE_LIMIT_MS },
+        (advertisement) => {
+          this.processAdvertisementUpdate(advertisement).catch((error) => {
+            this.error("Error processing advertisement:", error);
+          });
+        },
+      );
+      this.advertisementSubscriptionActive = true;
+      this.log(`Subscribed to BLE advertisements for ${peripheralUuid}`);
+    } catch (error) {
+      this.advertisementSubscriptionActive = false;
+      this.log(`Could not subscribe to BLE advertisements, using find/GATT fallback: ${error.message || error}`);
+    }
+  }
+
+  async stopAdvertisementSubscription() {
+    if (!this.advertisementSubscriptionActive || !this.supportsAdvertisementSubscriptions()) {
+      return;
+    }
+
+    const peripheralUuid = this.getPeripheralUuid();
+    if (!peripheralUuid) {
+      return;
+    }
+
+    try {
+      await this.homey.ble.unsubscribeFromAdvertisements(peripheralUuid);
+      this.log(`Unsubscribed from BLE advertisements for ${peripheralUuid}`);
+    } catch (error) {
+      this.log(`Failed to unsubscribe from BLE advertisements: ${error.message || error}`);
+    } finally {
+      this.advertisementSubscriptionActive = false;
+    }
+  }
+
+  async processAdvertisementUpdate(advertisement) {
+    if (!advertisement || !this.advertisementMatchesTarget(advertisement)) {
+      return;
+    }
+
+    if (typeof advertisement.rssi === "number") {
+      await this.setCapabilityValue("measure_rssi", advertisement.rssi).catch((error) => {
+        this.error("Error setting 'measure_rssi' from advertisement:", error);
+      });
+      if (advertisement.rssi <= MIN_CONNECTABLE_RSSI) {
+        await this.setWarning(`RSSI too weak for active BLE connection (${advertisement.rssi} dBm); using advertisements only.`);
+      } else {
+        await this.setWarning(null).catch((error) => this.error("Error clearing RSSI warning:", error));
+      }
+    }
+
+    const serviceData = Array.isArray(advertisement.serviceData) ? advertisement.serviceData : [];
+    serviceData.forEach((entry) => {
+      if (!entry || !entry.data) {
+        return;
+      }
+
+      const data = Buffer.isBuffer(entry.data) ? entry.data : Buffer.from(entry.data, "hex");
+      const dataString = data.toString("ascii").trim();
+      if (dataString.includes("T=") && dataString.includes("H=")) {
+        this.updateTag(data).catch((error) => this.error("Error updating from advertisement:", error));
+      }
+    });
+  }
+
+  async shouldSkipActiveConnection(advertisement) {
+    if (!advertisement || typeof advertisement.rssi !== "number" || advertisement.rssi > MIN_CONNECTABLE_RSSI) {
+      return false;
+    }
+
+    await this.processAdvertisementUpdate(advertisement);
+    this.log(`Skipping active BLE connection because RSSI is ${advertisement.rssi} dBm (threshold: ${MIN_CONNECTABLE_RSSI} dBm).`);
+    return true;
   }
 
   /**
@@ -107,6 +237,14 @@ class MyDevice extends Device {
    */
   async onDeleted() {
     this.log("LYWSDCGQ/01ZM BLE has been deleted");
+    await this.stopAdvertisementSubscription();
+    await this.stopBLESubscription();
+    this.polling = false;
+    clearInterval(this.pollingInterval);
+  }
+
+  async onUninit() {
+    await this.stopAdvertisementSubscription();
     await this.stopBLESubscription();
     this.polling = false;
     clearInterval(this.pollingInterval);
@@ -122,6 +260,10 @@ class MyDevice extends Device {
 
     try {
       const advertisement = await this.homey.ble.find(uuid);
+      if (await this.shouldSkipActiveConnection(advertisement)) {
+        return;
+      }
+
       const peripheral = await advertisement.connect();
       this.log(`Connected to device: ${uuid}`);
 
@@ -216,6 +358,10 @@ class MyDevice extends Device {
     try {
       await this.setWarning(null).catch(err => this.error("Error clearing warning before subscription:", err));
       const advertisement = await this.homey.ble.find(uuid);
+      if (await this.shouldSkipActiveConnection(advertisement)) {
+        return;
+      }
+
       const peripheral = await advertisement.connect();
       this.log(`Connected to device: ${uuid}`);
 
@@ -423,6 +569,9 @@ class MyDevice extends Device {
    * Poll device periodically
    */
   pollDevice() {
+    if (this.pollingInterval) {
+      clearInterval(this.pollingInterval);
+    }
     this.pollingInterval = setInterval(() => this.emit("poll"), this.reconnectInterval * 1000);
   }
 }

--- a/drivers/xiaomi-thermometer-ble2/driver.js
+++ b/drivers/xiaomi-thermometer-ble2/driver.js
@@ -51,6 +51,7 @@ class MyDriver extends Driver {
             },
             store: {
               peripheralUuid: advertisement.uuid,
+              address: advertisement.address,
             },
           };
         });

--- a/drivers/xiaomi-thermometer-ble3/device.js
+++ b/drivers/xiaomi-thermometer-ble3/device.js
@@ -1,6 +1,8 @@
 "use strict";
 
 const { Device } = require("homey");
+const ADVERTISEMENT_RATE_LIMIT_MS = 5000;
+const MIN_CONNECTABLE_RSSI = -85;
 
 class XiaomiThermometerDevice extends Device {
   /**
@@ -40,14 +42,141 @@ class XiaomiThermometerDevice extends Device {
     // Get initial settings
     this.temperatureOffset = this.getSetting("temperature_offset") || 0;
     this.reconnectInterval = this.getSetting("reconnect_interval") || 300; // Default to 5 minutes
+    this.advertisementSubscriptionActive = false;
     this.log(`Reconnect interval is set to ${this.reconnectInterval} seconds.`);
 
+    await this.startAdvertisementSubscription();
     // Subscribe to BLE notifications
     await this.subscribeToBLENotifications();
 
     // Set up polling
     this.addListener("poll", this.subscribeToBLENotifications.bind(this));
     this.pollDevice();
+  }
+
+  getPeripheralUuid() {
+    const store = typeof this.getStore === "function" ? this.getStore() : {};
+    const storePeripheralUuid = store && typeof store.peripheralUuid === "string" ? store.peripheralUuid : "";
+    if (storePeripheralUuid) {
+      return storePeripheralUuid.toLowerCase().replace(/:/g, "");
+    }
+
+    const data = this.getData() || {};
+    const legacyId = typeof data.id === "string" ? data.id : "";
+    return legacyId.toLowerCase().replace(/:/g, "");
+  }
+
+  advertisementMatchesTarget(advertisement) {
+    const store = typeof this.getStore === "function" ? this.getStore() : {};
+    const data = this.getData() || {};
+    const targetAddress = (store.address || data.id || "").toLowerCase();
+    const targetUuid = this.getPeripheralUuid();
+    const advertisementAddress = (advertisement && advertisement.address || "").toLowerCase();
+    const advertisementUuid = (advertisement && advertisement.uuid || "").toLowerCase().replace(/:/g, "");
+
+    return Boolean(
+      (targetAddress && advertisementAddress === targetAddress)
+      || (targetUuid && advertisementUuid === targetUuid),
+    );
+  }
+
+  supportsAdvertisementSubscriptions() {
+    return Boolean(
+      typeof this.homey.hasFeature === "function"
+      && this.homey.hasFeature("ble-advertisements")
+      && this.homey.ble
+      && typeof this.homey.ble.subscribeToAdvertisements === "function"
+      && typeof this.homey.ble.unsubscribeFromAdvertisements === "function",
+    );
+  }
+
+  async startAdvertisementSubscription() {
+    if (!this.supportsAdvertisementSubscriptions()) {
+      this.log("BLE advertisement subscriptions are not available; using find/GATT fallback.");
+      return;
+    }
+
+    const peripheralUuid = this.getPeripheralUuid();
+    if (!peripheralUuid) {
+      this.log("Missing peripheral UUID; using find/GATT fallback.");
+      return;
+    }
+
+    try {
+      await this.homey.ble.subscribeToAdvertisements(
+        peripheralUuid,
+        { rateLimitMs: ADVERTISEMENT_RATE_LIMIT_MS },
+        (advertisement) => {
+          this.processAdvertisementUpdate(advertisement).catch((error) => {
+            this.error("Error processing advertisement:", error);
+          });
+        },
+      );
+      this.advertisementSubscriptionActive = true;
+      this.log(`Subscribed to BLE advertisements for ${peripheralUuid}`);
+    } catch (error) {
+      this.advertisementSubscriptionActive = false;
+      this.log(`Could not subscribe to BLE advertisements, using find/GATT fallback: ${error.message || error}`);
+    }
+  }
+
+  async stopAdvertisementSubscription() {
+    if (!this.advertisementSubscriptionActive || !this.supportsAdvertisementSubscriptions()) {
+      return;
+    }
+
+    const peripheralUuid = this.getPeripheralUuid();
+    if (!peripheralUuid) {
+      return;
+    }
+
+    try {
+      await this.homey.ble.unsubscribeFromAdvertisements(peripheralUuid);
+      this.log(`Unsubscribed from BLE advertisements for ${peripheralUuid}`);
+    } catch (error) {
+      this.log(`Failed to unsubscribe from BLE advertisements: ${error.message || error}`);
+    } finally {
+      this.advertisementSubscriptionActive = false;
+    }
+  }
+
+  async processAdvertisementUpdate(advertisement) {
+    if (!advertisement || !this.advertisementMatchesTarget(advertisement)) {
+      return;
+    }
+
+    if (typeof advertisement.rssi === "number") {
+      await this.setCapabilityValue("measure_rssi", advertisement.rssi).catch((error) => {
+        this.error("Error setting 'measure_rssi' from advertisement:", error);
+      });
+      if (advertisement.rssi <= MIN_CONNECTABLE_RSSI) {
+        await this.setWarning(`RSSI too weak for active BLE connection (${advertisement.rssi} dBm); using advertisements only.`);
+      } else {
+        await this.setWarning(null).catch((error) => this.error("Error clearing RSSI warning:", error));
+      }
+    }
+
+    const serviceData = Array.isArray(advertisement.serviceData) ? advertisement.serviceData : [];
+    serviceData.forEach((entry) => {
+      if (!entry || !entry.data) {
+        return;
+      }
+
+      const data = Buffer.isBuffer(entry.data) ? entry.data : Buffer.from(entry.data, "hex");
+      if (data.length === 5) {
+        this.updateTag(data).catch((error) => this.error("Error updating from advertisement:", error));
+      }
+    });
+  }
+
+  async shouldSkipActiveConnection(advertisement) {
+    if (!advertisement || typeof advertisement.rssi !== "number" || advertisement.rssi > MIN_CONNECTABLE_RSSI) {
+      return false;
+    }
+
+    await this.processAdvertisementUpdate(advertisement);
+    this.log(`Skipping active BLE connection because RSSI is ${advertisement.rssi} dBm (threshold: ${MIN_CONNECTABLE_RSSI} dBm).`);
+    return true;
   }
 
   /**
@@ -87,6 +216,14 @@ class XiaomiThermometerDevice extends Device {
    */
   async onDeleted() {
     this.log("Xiaomi LYWSD03MMC BLE (non ATC) has been deleted");
+    await this.stopAdvertisementSubscription();
+    await this.stopBLESubscription();
+    this.polling = false;
+    clearInterval(this.pollingInterval);
+  }
+
+  async onUninit() {
+    await this.stopAdvertisementSubscription();
     await this.stopBLESubscription();
     this.polling = false;
     clearInterval(this.pollingInterval);
@@ -105,6 +242,10 @@ class XiaomiThermometerDevice extends Device {
 
     try {
       const advertisement = await this.homey.ble.find(uuid);
+      if (await this.shouldSkipActiveConnection(advertisement)) {
+        return;
+      }
+
       const peripheral = await advertisement.connect();
       this.log(`Connected to device: ${uuid}`);
 

--- a/drivers/xiaomi-thermometer-ble3/driver.js
+++ b/drivers/xiaomi-thermometer-ble3/driver.js
@@ -59,6 +59,7 @@ class XiaomiThermometerDriver extends Driver {
             },
             store: {
               peripheralUuid: advertisement.uuid,
+              address: advertisement.address,
             },
           };
         });


### PR DESCRIPTION
## Summary
- Add BLE advertisement subscriptions for BLE2 and BLE3 devices with feature-gated fallback to existing find/GATT paths.
- Keep RSSI updated from advertisements and skip active BLE connections when RSSI is <= -85 dBm.
- Preserve passive FE95 advertisement handling for LYWSD02MMC and avoid polling ATC devices that use advertisement subscriptions.

## Validation
- node --check on modified JavaScript files
- git diff --check
- homey app validate